### PR TITLE
New API url with more capabilities

### DIFF
--- a/YahooFinance.NET/YahooFinanceClient.cs
+++ b/YahooFinance.NET/YahooFinanceClient.cs
@@ -10,7 +10,7 @@ namespace YahooFinance.NET
 	{
 		private const int MinimumDateRangeDays = -30;
 
-		private const string BaseUrl = "http://ichart.finance.yahoo.com/table.csv?s=";
+		private const string BaseUrl = "http://real-chart.finance.yahoo.com/table.csv?s=";
 
 		private enum HistoryType
 		{

--- a/YahooFinance.NET/YahooFinanceClient.cs
+++ b/YahooFinance.NET/YahooFinanceClient.cs
@@ -20,19 +20,37 @@ namespace YahooFinance.NET
 			Month,
 		}
 
-		//date range is not supported for monthly data
 		public List<YahooHistoricalPriceData> GetMonthlyHistoricalPriceData(string yahooStockCode)
 		{
 			return GetHistoricalPriceData(yahooStockCode, null, null, HistoryType.Month);
 		}
 
-		//date range is not supported for weekly data
-		public List<YahooHistoricalPriceData> GetWeeklyHistoricalPriceData(string yahooStockCode)
+        public List<YahooHistoricalPriceData> GetMonthlyHistoricalPriceData(string yahooStockCode, DateTime startDate)
+        {
+            return GetHistoricalPriceData(yahooStockCode, startDate, null, HistoryType.Month);
+        }
+
+        public List<YahooHistoricalPriceData> GetMonthlyHistoricalPriceData(string yahooStockCode, DateTime startDate, DateTime endDate)
+        {
+            return GetHistoricalPriceData(yahooStockCode, startDate, endDate, HistoryType.Month);
+        }
+
+        public List<YahooHistoricalPriceData> GetWeeklyHistoricalPriceData(string yahooStockCode)
 		{
 			return GetHistoricalPriceData(yahooStockCode, null, null, HistoryType.Week);
 		}
 
-		public List<YahooHistoricalPriceData> GetDailyHistoricalPriceData(string yahooStockCode)
+        public List<YahooHistoricalPriceData> GetWeeklyHistoricalPriceData(string yahooStockCode, DateTime startDate)
+        {
+            return GetHistoricalPriceData(yahooStockCode, startDate, null, HistoryType.Week);
+        }
+
+        public List<YahooHistoricalPriceData> GetWeeklyHistoricalPriceData(string yahooStockCode, DateTime startDate, DateTime endDate)
+        {
+            return GetHistoricalPriceData(yahooStockCode, startDate, endDate, HistoryType.Week);
+        }
+
+        public List<YahooHistoricalPriceData> GetDailyHistoricalPriceData(string yahooStockCode)
 		{
 			return GetHistoricalPriceData(yahooStockCode, null, null, HistoryType.Day);
 		}
@@ -50,7 +68,7 @@ namespace YahooFinance.NET
 		private List<YahooHistoricalPriceData> GetHistoricalPriceData(string yahooStockCode, DateTime? startDate, DateTime? endDate, HistoryType historyType)
 		{
 			var dateRangeOption = string.Empty;
-			var addDateRangeOption = historyType == HistoryType.Day && startDate.HasValue && endDate.HasValue;
+			var addDateRangeOption = startDate.HasValue && endDate.HasValue;
 			if (addDateRangeOption)
 			{
 				var startDateValue = startDate.Value;
@@ -172,7 +190,8 @@ namespace YahooFinance.NET
 
 		private string GetStartDate(DateTime date)
 		{
-			var month = $"&a={date.Month}";
+            // API uses zero-based month numbering
+			var month = $"&a={date.Month - 1}";
 			var day = $"&b={date.Day}";
 			var year = $"&c={date.Year}";
 
@@ -182,7 +201,8 @@ namespace YahooFinance.NET
 
 		private string GetEndDate(DateTime date)
 		{
-			var month = $"&d={date.Month}";
+            // API uses zero-based month numbering
+            var month = $"&d={date.Month - 1}";
 			var day = $"&e={date.Day}";
 			var year = $"&f={date.Year}";
 

--- a/YahooFinance.NET/YahooFinanceClient.cs
+++ b/YahooFinance.NET/YahooFinanceClient.cs
@@ -105,7 +105,7 @@ namespace YahooFinance.NET
 					High = decimal.Parse(values[2], CultureInfo.InvariantCulture),
 					Low = decimal.Parse(values[3], CultureInfo.InvariantCulture),
 					Close = decimal.Parse(values[4], CultureInfo.InvariantCulture),
-					Volume = int.Parse(values[5], CultureInfo.InvariantCulture),
+					Volume = long.Parse(values[5], CultureInfo.InvariantCulture),
 					AdjClose = decimal.Parse(values[6], CultureInfo.InvariantCulture)
 				};
 				historicalPriceData.Add(newPriceData);
@@ -151,7 +151,10 @@ namespace YahooFinance.NET
 				{
 					var historicalData = response.Content.ReadAsStringAsync().Result;
 
-					return historicalData;
+                    if (response.IsSuccessStatusCode)
+                        return historicalData;
+                    else
+                        return string.Empty;
 				}
 			}
 		}

--- a/YahooFinance.NET/YahooHistoricalDividendData.cs
+++ b/YahooFinance.NET/YahooHistoricalDividendData.cs
@@ -2,6 +2,7 @@
 
 namespace YahooFinance.NET
 {
+    [Serializable]
 	public class YahooHistoricalDividendData
 	{
 		public DateTime Date { get; set; }

--- a/YahooFinance.NET/YahooHistoricalPriceData.cs
+++ b/YahooFinance.NET/YahooHistoricalPriceData.cs
@@ -2,6 +2,7 @@
 
 namespace YahooFinance.NET
 {
+    [Serializable]
 	public class YahooHistoricalPriceData
 	{
 		public DateTime Date { get; set; }

--- a/YahooFinance.NET/YahooHistoricalPriceData.cs
+++ b/YahooFinance.NET/YahooHistoricalPriceData.cs
@@ -10,7 +10,7 @@ namespace YahooFinance.NET
 		public decimal High { get; set; }
 		public decimal Low { get; set; }
 		public decimal Close { get; set; }
-		public int Volume { get; set; }
+		public long Volume { get; set; }
 		public decimal AdjClose { get; set; }
 	}
 }


### PR DESCRIPTION
The historical price API has changed URLs and appears to support date-bound queries across all frequencies, so I made the relevant updates. It seems that the month parts of the API query are zero-indexed (for some reason...), so I fixed those. Also, I changed Volume to a long after running into an overflow error.